### PR TITLE
Added cueMethod option to toggle or cycle through cuelist (#15)

### DIFF
--- a/src/cueButton.vue
+++ b/src/cueButton.vue
@@ -39,6 +39,9 @@ module.exports = {
 		},
 		'textColor' : {
 		    default: '#333'
+		},
+		'method' : {
+			default: 'toggle'
 		}
 	},
 	data: function() {
@@ -48,10 +51,18 @@ module.exports = {
 	},
 	methods: {
 		toggleCue: function() {
-			if (this.isActive()) {
-				this.$root.sendCommand('cuelistRelease ' + this.$props.cue);
-			} else {
-				this.$root.sendCommand('cuelistGo ' + this.$props.cue);
+			switch(this.$props.method){
+				case 'toggle':
+					if(this.isActive())
+					  this.$root.sendCommand('cuelistRelease ' + this.$props.cue);
+					else
+					  this.$root.sendCommand('cuelistGo ' + this.$props.cue);
+					break;
+				case 'list':
+					this.$root.sendCommand('cuelistGo ' + this.$props.cue);
+					break;
+				default:
+					console.log(`method ${this.$props.method} is not valid`);
 			}
 			this.$data.fading = true;
 			var data = this.$data;


### PR DESCRIPTION
* Add files via upload

Added cueMethod function. Default is a simple toggle. By defining the method attribute in your cue-button element in pgControls.vue and assigning value "list", triggering cue-button will send go command to MPC while cuelist is active, instead of release. default to method attribute is toggle and will behave that way if method is not defined.

* Change request - Switch function

implement @jay-oswald switch code. removed cueMethod function (obsolete).

* updated - invalid reference 

Fixed invalid reference on line 65